### PR TITLE
Some fixes in swagger.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # IDE
 .idea
+swagger-draft.yml

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It's a great way to generate in a couple of minutes fully functional web applica
 
 ## Swagger usage
 
-- Step 0: Open [swagger editor](https://petstore.swagger.io/)
+- Step 0: Open [Swagger UI](https://petstore.swagger.io/)
 - Step 1: Put in address bar path to [swagger.yml](https://raw.githubusercontent.com/jetbase-io/jetbase-swagger/master/swagger.yml)
 
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -91,7 +91,7 @@ paths:
           in: query
           type: string
           required: false
-          description: Email for filtering results.
+          description: Email or part of email for filtering results.
         - name: page
           in: query
           type: integer

--- a/swagger.yml
+++ b/swagger.yml
@@ -112,7 +112,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/User'
+              $ref: "#/definitions/User"
         '400':
           description: Invalid user ID.
         '401':
@@ -150,7 +150,7 @@ paths:
         '200':
           description: Get current user information successfully.
           schema:
-            $ref: '#/definitions/User'
+            $ref: "#/definitions/User"
         '401':
           description: User need to log in first.
   /users/{user_id}:
@@ -234,7 +234,7 @@ paths:
           description: Password to be updated, the attribute 'old_password' is optional when the API is called by the system administrator.
           required: true
           schema:
-            $ref: '#/definitions/Password'
+            $ref: "#/definitions/Password"
       tags:
         - "user"
       responses:

--- a/swagger.yml
+++ b/swagger.yml
@@ -271,6 +271,12 @@ definitions:
       role_id:
         type: "integer"
         format: "int32"
+    required:
+      - first_name
+      - last_name
+      - email
+      - password
+      - password_confirmation
   UserUpdate:
     type: "object"
     properties:

--- a/swagger.yml
+++ b/swagger.yml
@@ -43,12 +43,12 @@ paths:
         - "application/json"
       parameters:
         - name: "email"
-          in: "query"
+          in: "body"
           description: "The user's email for login"
           required: true
           type: "string"
         - name: "password"
-          in: "query"
+          in: "body"
           description: "The password for login in clear text"
           required: true
           type: "string"

--- a/swagger.yml
+++ b/swagger.yml
@@ -135,7 +135,7 @@ paths:
           description: "Created user object"
           required: true
           schema:
-            $ref: "#/definitions/User"
+            $ref: "#/definitions/UserCreate"
       responses:
         default:
           description: "successful operation"

--- a/swagger.yml
+++ b/swagger.yml
@@ -302,6 +302,7 @@ definitions:
       id:
         type: "integer"
         format: "int32"
+        example: 1
       first_name:
         type: "string"
       last_name:

--- a/swagger.yml
+++ b/swagger.yml
@@ -69,6 +69,7 @@ paths:
               rate_limit:
                 type: integer
                 description: "calls per hour allowed by the user"
+                example: 3600
               expires_after:
                 type: string
                 format: date-time

--- a/swagger.yml
+++ b/swagger.yml
@@ -184,7 +184,7 @@ paths:
       parameters:
         - name: "user_id"
           in: "path"
-          description: "name that need to be updated"
+          description: "user id which need to be updated"
           required: true
           type: "integer"
         - in: "body"

--- a/swagger.yml
+++ b/swagger.yml
@@ -249,7 +249,8 @@ paths:
         '500':
           description: Unexpected internal errors.
 definitions:
-  UserCreate: "object"
+  UserCreate:
+    type: "object"
     properties:
       first_name:
         type: "string"

--- a/swagger.yml
+++ b/swagger.yml
@@ -112,7 +112,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: "#/definitions/User"
+              $ref: "#/definitions/UserGet"
         '400':
           description: Invalid user ID.
         '401':
@@ -150,7 +150,7 @@ paths:
         '200':
           description: Get current user information successfully.
           schema:
-            $ref: "#/definitions/User"
+            $ref: "#/definitions/UserGet"
         '401':
           description: User need to log in first.
   /users/{user_id}:
@@ -172,7 +172,7 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/User"
+            $ref: "#/definitions/UserGet"
         404:
           description: "User not found"
     put:
@@ -194,7 +194,7 @@ paths:
           description: "Updated user object"
           required: true
           schema:
-            $ref: "#/definitions/User"
+            $ref: "#/definitions/UserUpdate"
       responses:
         400:
           description: "Invalid user supplied"
@@ -265,7 +265,19 @@ definitions:
       role_id:
         type: "integer"
         format: "int32"
-  User:
+  UserUpdate:
+    type: "object"
+    properties:
+      first_name:
+        type: "string"
+      last_name:
+        type: "string"
+      email:
+        type: "string"
+      role_id:
+        type: "integer"
+        format: "int32"
+  UserGet:
     type: "object"
     properties:
       id:
@@ -276,8 +288,6 @@ definitions:
       last_name:
         type: "string"
       email:
-        type: "string"
-      password:
         type: "string"
       role_id:
         type: "integer"

--- a/swagger.yml
+++ b/swagger.yml
@@ -130,6 +130,7 @@ paths:
               count:
                 type: integer
                 description: The count of found users
+                example: 1
         '401':
           description: User need to log in first.
         '403':

--- a/swagger.yml
+++ b/swagger.yml
@@ -93,34 +93,43 @@ paths:
     get:
       summary: Get registered users.
       description: |
-        This endpoint is for user to search registered users, support for filtering results. Notice, by now this operation is only for administrator.
+        This endpoint is for user to search registered users, support for filtering results.<br>
+        Notice, by now this operation is only for administrator.<br>
+        Pagination: only if `limit` param passed, otherwise returns all users
       parameters:
         - name: email
           in: query
           type: string
           required: false
           description: Email or part of email for filtering results.
-        - name: page
+        - name: limit
           in: query
           type: integer
           format: int32
           required: false
-          description: 'The page number, default is 1.'
-        - name: page_size
+          description: The count of users per page, default unlimited
+        - name: offset
           in: query
           type: integer
           format: int32
           required: false
-          description: The size of per page.
+          description: The count of skip users, default is 0
       tags:
         - "user"
       responses:
         '200':
           description: Searched for users successfully.
           schema:
-            type: array
-            items:
-              $ref: "#/definitions/UserGet"
+            type: object
+            properties:
+              items:
+                description: The collection of found users
+                type: array
+                items:
+                  $ref: "#/definitions/UserGet"
+              count:
+                type: integer
+                description: The count of found users
         '401':
           description: User need to log in first.
         '403':

--- a/swagger.yml
+++ b/swagger.yml
@@ -44,7 +44,7 @@ paths:
       parameters:
         - name: "email"
           in: "query"
-          description: "The user name for login"
+          description: "The user's email for login"
           required: true
           type: "string"
         - name: "password"

--- a/swagger.yml
+++ b/swagger.yml
@@ -56,6 +56,7 @@ paths:
         200:
           description: "successful operation"
           schema:
+            description: "authorization token"
             type: "string"
           headers:
             X-Rate-Limit:

--- a/swagger.yml
+++ b/swagger.yml
@@ -271,6 +271,7 @@ definitions:
         type: "string"
       email:
         type: "string"
+        format: email
       password:
         type: "string"
       password_confirmation:
@@ -293,6 +294,7 @@ definitions:
         type: "string"
       email:
         type: "string"
+        format: email
       role_id:
         type: "integer"
         format: "int32"
@@ -309,6 +311,7 @@ definitions:
         type: "string"
       email:
         type: "string"
+        format: email
       role_id:
         type: "integer"
         format: "int32"

--- a/swagger.yml
+++ b/swagger.yml
@@ -56,7 +56,6 @@ paths:
         200:
           description: "successful operation"
           schema:
-            description: "authorization token"
             type: "string"
           headers:
             X-Rate-Limit:

--- a/swagger.yml
+++ b/swagger.yml
@@ -177,7 +177,7 @@ paths:
       tags:
         - "user"
       summary: "Updated user"
-      description: "This can only be done by the logged in user."
+      description: "This can only be done by the logged in user. If passed role_id, only admin can change role, otherwise this field will be ignored"
       operationId: "updateUser"
       produces:
         - "application/json"

--- a/swagger.yml
+++ b/swagger.yml
@@ -143,8 +143,15 @@ paths:
           schema:
             $ref: "#/definitions/UserCreate"
       responses:
-        default:
-          description: "successful operation"
+        '200':
+          description: "user successfully created"
+          schema:
+            type: object
+            properties:
+              id:
+                type: integer
+                description: Id of created user
+                example: 1
   /users/current:
     get:
       summary: Get current user info.

--- a/swagger.yml
+++ b/swagger.yml
@@ -113,8 +113,6 @@ paths:
             type: array
             items:
               $ref: "#/definitions/UserGet"
-        '400':
-          description: Invalid user ID.
         '401':
           description: User need to log in first.
         '403':

--- a/swagger.yml
+++ b/swagger.yml
@@ -42,30 +42,37 @@ paths:
       produces:
         - "application/json"
       parameters:
-        - name: "email"
-          in: "body"
-          description: "The user's email for login"
-          required: true
-          type: "string"
-        - name: "password"
-          in: "body"
-          description: "The password for login in clear text"
-          required: true
-          type: "string"
+        - in: "body"
+          name: "body"
+          schema:
+            type: object
+            properties:
+              email:
+                type: string
+                format: email
+                description: "The user's email for login"
+              password:
+                type: string
+                format: password
+                description: "The password for login in clear text"
+            required:
+              - email
+              - password
       responses:
         200:
           description: "successful operation"
           schema:
-            type: "string"
-          headers:
-            X-Rate-Limit:
-              type: "integer"
-              format: "int32"
-              description: "calls per hour allowed by the user"
-            X-Expires-After:
-              type: "string"
-              format: "date-time"
-              description: "date in UTC when token expires"
+            type: object
+            properties:
+              token:
+                type: string
+              rate_limit:
+                type: integer
+                description: "calls per hour allowed by the user"
+              expires_after:
+                type: string
+                format: date-time
+                description: "date in UTC when token expires"
         400:
           description: "Invalid email/password supplied"
   /logout:

--- a/swagger.yml
+++ b/swagger.yml
@@ -249,6 +249,21 @@ paths:
         '500':
           description: Unexpected internal errors.
 definitions:
+  UserCreate: "object"
+    properties:
+      first_name:
+        type: "string"
+      last_name:
+        type: "string"
+      email:
+        type: "string"
+      password:
+        type: "string"
+      password_confirmation:
+        type: "string"
+      role_id:
+        type: "integer"
+        format: "int32"
   User:
     type: "object"
     properties:
@@ -283,16 +298,6 @@ definitions:
       new_password:
         type: "string"
         description: New password for marking as to be updated.
-  ApiResponse:
-    type: "object"
-    properties:
-      code:
-        type: "integer"
-        format: "int32"
-      type:
-        type: "string"
-      message:
-        type: "string"
 externalDocs:
   description: "Find out more about JetBase"
   url: "https://jetbase.io"


### PR DESCRIPTION
1. Remove unused definition ApiResponse
2. Pass login credentials email/password in body
3. User definition laid out for three separated definitions:
   - UserCreate - add `password_confirmation` prop
   - UserGet - returns user/s without `password`
   - UserUpdate - pass updating user's props map without id, id passes in request path
4. Small fixes in description